### PR TITLE
fix(webpack4): Add mode value to webpack config

### DIFF
--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -148,6 +148,7 @@ const buildWebpackConfigs = builds.map(
 
     return [
       {
+        mode: isProductionBuild ? 'production' : 'development',
         entry,
         output: {
           path: paths.dist,
@@ -218,6 +219,7 @@ const buildWebpackConfigs = builds.map(
         ]
       },
       {
+        mode: isProductionBuild ? 'production' : 'development',
         entry: {
           render:
             paths.renderEntry || path.join(__dirname, '../server/server.js')

--- a/config/webpack/webpack.config.ssr.js
+++ b/config/webpack/webpack.config.ssr.js
@@ -166,6 +166,7 @@ const buildWebpackConfigs = builds.map(
 
     return [
       {
+        mode: isProductionBuild ? 'production' : 'development',
         entry: clientEntry,
         devtool: isStartScript ? 'inline-source-map' : false,
         output: {
@@ -250,6 +251,7 @@ const buildWebpackConfigs = builds.map(
         )
       },
       {
+        mode: isProductionBuild ? 'production' : 'development',
         entry: serverEntry,
         watch: isStartScript,
         externals: [

--- a/package.json
+++ b/package.json
@@ -94,8 +94,8 @@
     "svgo-loader": "^2.0.0",
     "url-loader": "^0.6.2",
     "validate-npm-package-name": "^3.0.0",
-    "webpack": "^4.0.1",
-    "webpack-dev-server": "^3.1.0",
+    "webpack": "^4.16.2",
+    "webpack-dev-server": "^3.1.5",
     "webpack-node-externals": "^1.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I think this fixes the [slow reload issue](https://github.com/seek-oss/sku/pull/125#issuecomment-400884307) that @markdalgleish found.

Without `mode` set, Webpack uses `production` by default, which will obviously result in slow builds.

In `development` mode there's no discernable difference in hot reload performance between this branch and master for `npm run test-manual`.